### PR TITLE
Introduce PrimitiveByteCodable protocols and remove preferred endianness

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,5 +16,5 @@ authors:
 given-names: "Andreas"
 orcid: "https://orcid.org/0000-0002-1680-237X"
 title: "SpeziNetworking"
-doi: 10.5281/zenodo.7538165
+doi: 10.5281/zenodo.11508061
 url: "https://github.com/StanfordSpezi/SpeziNetworking"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,9 +12,9 @@ authors:
 - family-names: "Schmiedmayer"
   given-names: "Paul"
   orcid: "https://orcid.org/0000-0002-8607-9148"
-- family-names: "Ravi"
-  given-names: "Vishnu"
-  orcid: "https://orcid.org/0000-0003-0359-1275"
+- family-names: "Bauer"
+given-names: "Andreas"
+orcid: "https://orcid.org/0000-0002-1680-237X"
 title: "SpeziNetworking"
 doi: 10.5281/zenodo.7538165
 url: "https://github.com/StanfordSpezi/SpeziNetworking"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
   given-names: "Paul"
   orcid: "https://orcid.org/0000-0002-8607-9148"
 - family-names: "Bauer"
-given-names: "Andreas"
-orcid: "https://orcid.org/0000-0002-1680-237X"
+  given-names: "Andreas"
+  orcid: "https://orcid.org/0000-0002-1680-237X"
 title: "SpeziNetworking"
 doi: 10.5281/zenodo.11508061
 url: "https://github.com/StanfordSpezi/SpeziNetworking"

--- a/README.md
+++ b/README.md
@@ -26,14 +26,20 @@ SpeziNetworking provides easy to use infrastructure in networking applications.
 The `ByteCoding` package provides the necessary infrastructure to make encoding and decoding of a type to or from its
 respective binary representation easy to use.
 
+|                                                         Type                                                          | Description                                                           |
+|:---------------------------------------------------------------------------------------------------------------------:|-----------------------------------------------------------------------|
+|   [`ByteCodable`](https://swiftpackageindex.com/stanfordspezi/spezinetworking/documentation/bytecoding/bytecodable)   | A type that is encodable to and decodable from a byte representation. |
+| [`ByteEncodable`](https://swiftpackageindex.com/stanfordspezi/spezinetworking/documentation/bytecoding/byteencodable) | A type that is decodable to a byte representation.                    |
+| [`ByteDecodable`](https://swiftpackageindex.com/stanfordspezi/spezinetworking/documentation/bytecoding/bytedecodable) | A type that is decodable from a byte representation.                  |
+
 ### SpeziNumerics
 
 Implementation of numeric types that are not supported out of the box in the standard library or are only found in networking protocols.
 
-|                                                                      Type                                                                      | Description                                                  |
-|:----------------------------------------------------------------------------------------------------------------------------------------------:|--------------------------------------------------------------|
-|                [MedFloat16](https://swiftpackageindex.com/stanfordspezi/spezinetworking/documentation/spezinumerics/medfloat16)                | Medical 16-bit float using base 10                           |
-|  [Int24/UInt24 Support](https://swiftpackageindex.com/stanfordspezi/spezinetworking/1.0.0/documentation/spezinumerics#24-bit-integer-support)  | Support reading and writing Int24 and UInt24 with ByteBuffer |
+|                                                                  Type                                                                  | Description                                                  |
+|:--------------------------------------------------------------------------------------------------------------------------------------:|--------------------------------------------------------------|
+|           [`MedFloat16`](https://swiftpackageindex.com/stanfordspezi/spezinetworking/documentation/spezinumerics/medfloat16)           | Medical 16-bit float using base 10                           |
+| [Int24/UInt24 Support](https://swiftpackageindex.com/stanfordspezi/spezinetworking/documentation/spezinumerics#24-bit-integer-support) | Support reading and writing Int24 and UInt24 with ByteBuffer |
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ SPDX-License-Identifier: MIT
 [![codecov](https://codecov.io/gh/StanfordSpezi/SpeziNetworking/graph/badge.svg?token=emNLUokqWO)](https://codecov.io/gh/StanfordSpezi/SpeziNetworking)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpeziNetworking%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/StanfordSpezi/SpeziNetworking)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpeziNetworking%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/StanfordSpezi/SpeziNetworking)
-
-
+[![DOI](https://zenodo.org/badge/811321013.svg)](https://zenodo.org/doi/10.5281/zenodo.11508061)
 A collection of networking-related infrastructure to support Spezi applications.
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ respective binary representation easy to use.
 
 Implementation of numeric types that are not supported out of the box in the standard library or are only found in networking protocols.
 
+|                                                                      Type                                                                      | Description                                                  |
+|:----------------------------------------------------------------------------------------------------------------------------------------------:|--------------------------------------------------------------|
+|                [MedFloat16](https://swiftpackageindex.com/stanfordspezi/spezinetworking/documentation/spezinumerics/medfloat16)                | Medical 16-bit float using base 10                           |
+|  [Int24/UInt24 Support](https://swiftpackageindex.com/stanfordspezi/spezinetworking/1.0.0/documentation/spezinumerics#24-bit-integer-support)  | Support reading and writing Int24 and UInt24 with ByteBuffer |
+
 ## Setup
 
 You need to add the SpeziNetworking Swift package to

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ SPDX-License-Identifier: MIT
 
 [![Build and Test](https://github.com/StanfordSpezi/SpeziNetworking/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/StanfordSpezi/SpeziNetworking/actions/workflows/build-and-test.yml)
 [![codecov](https://codecov.io/gh/StanfordSpezi/SpeziNetworking/graph/badge.svg?token=emNLUokqWO)](https://codecov.io/gh/StanfordSpezi/SpeziNetworking)
+[![DOI](https://zenodo.org/badge/811321013.svg)](https://zenodo.org/doi/10.5281/zenodo.11508061)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpeziNetworking%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/StanfordSpezi/SpeziNetworking)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpeziNetworking%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/StanfordSpezi/SpeziNetworking)
-[![DOI](https://zenodo.org/badge/811321013.svg)](https://zenodo.org/doi/10.5281/zenodo.11508061)
 A collection of networking-related infrastructure to support Spezi applications.
 
 ## Overview

--- a/Sources/ByteCoding/ByteCodable+Deprecated.swift
+++ b/Sources/ByteCoding/ByteCodable+Deprecated.swift
@@ -1,0 +1,161 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import NIOCore
+
+
+// MARK: - ByteBuffer
+
+extension ByteDecodable {
+    /// Decode the type from the `ByteBuffer`.
+    ///
+    /// Initialize a new instance using the byte representation provided by the `ByteBuffer`.
+    /// This call should move the `readerIndex` forwards.
+    ///
+    /// - Note: Returns nil if no valid byte representation could be found.
+    /// - Parameters:
+    ///   - byteBuffer: The ByteBuffer to read from.
+    ///   - endianness: The preferred endianness to use for decoding if applicable.
+    ///     This might not apply to certain data structures that operate on single byte level.
+    @available(*, deprecated, message: "Preferred Endianness was removed. Refer to PrimitiveByteDecodable/init(from:endianness:) if applicable.")
+    @_documentation(visibility: internal)
+    @_disfavoredOverload
+    init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        self.init(from: &byteBuffer)
+    }
+}
+
+
+extension PrimitiveByteDecodable {
+    /// Decode the type from the `ByteBuffer`.
+    ///
+    /// Initialize a new instance using the byte representation provided by the `ByteBuffer`.
+    /// This call should move the `readerIndex` forwards.
+    ///
+    /// - Note: Returns nil if no valid byte representation could be found.
+    /// - Parameters:
+    ///   - byteBuffer: The ByteBuffer to read from.
+    ///   - endianness: The preferred endianness to use for decoding if applicable.
+    ///     This might not apply to certain data structures that operate on single byte level.
+    @available(*, deprecated, renamed: "init(from:endianness:)", message: "Preferred Endianness was replaced by the PrimitiveCodable protocols.")
+    @_documentation(visibility: internal)
+    init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        self.init(from: &byteBuffer, endianness: endianness)
+    }
+}
+
+
+extension ByteEncodable {
+    /// Encode into the `ByteBuffer`.
+    ///
+    /// Encode the byte representation of this type into the provided `ByteBuffer`.
+    /// This call should move the `writerIndex` forwards.
+    ///
+    /// - Parameters:
+    ///   - byteBuffer: The ByteBuffer to write into.
+    ///   - endianness: The preferred endianness to use for encoding if applicable.
+    ///     This might not apply to certain data structures that operate on single byte level.
+    @available(*, deprecated, message: "Preferred Endianness was removed. Refer to PrimitiveByteEncodable/encode(to:endianness:) if applicable.")
+    @_documentation(visibility: internal)
+    @_disfavoredOverload
+    func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        self.encode(to: &byteBuffer)
+    }
+}
+
+
+extension PrimitiveByteEncodable {
+    /// Encode into the `ByteBuffer`.
+    ///
+    /// Encode the byte representation of this type into the provided `ByteBuffer`.
+    /// This call should move the `writerIndex` forwards.
+    ///
+    /// - Parameters:
+    ///   - byteBuffer: The ByteBuffer to write into.
+    ///   - endianness: The preferred endianness to use for encoding if applicable.
+    ///     This might not apply to certain data structures that operate on single byte level.
+    @available(*, deprecated, renamed: "encode(to:endianness:)", message: "Preferred Endianness was replaced by the PrimitiveCodable protocols.")
+    @_documentation(visibility: internal)
+    func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        self.encode(to: &byteBuffer, endianness: endianness)
+    }
+}
+
+// MARK: - Data
+
+extension ByteDecodable {
+    /// Decode the type from `Data`.
+    ///
+    /// Initialize a new instance using the byte representation provided.
+    ///
+    /// - Note: Returns nil if no valid byte representation could be found.
+    /// - Parameters:
+    ///   - data: The data to decode.
+    ///   - endianness: The preferred endianness to use for decoding if applicable.
+    ///     This might not apply to certain data structures that operate on single byte level.
+    @available(*, deprecated, message: "Preferred Endianness was removed. Refer to PrimitiveByteDecodable/init(data:endianness:) if applicable.")
+    @_documentation(visibility: internal)
+    @_disfavoredOverload
+    public init?(data: Data, preferredEndianness endianness: Endianness = .little) {
+        var buffer = ByteBuffer(data: data)
+        self.init(from: &buffer)
+    }
+}
+
+
+extension PrimitiveByteDecodable {
+    /// Decode the type from `Data`.
+    ///
+    /// Initialize a new instance using the byte representation provided.
+    ///
+    /// - Note: Returns nil if no valid byte representation could be found.
+    /// - Parameters:
+    ///   - data: The data to decode.
+    ///   - endianness: The preferred endianness to use for decoding if applicable.
+    ///     This might not apply to certain data structures that operate on single byte level.
+    @available(*, deprecated, renamed: "init(data:endianness:)", message: "Preferred Endianness was replaced by the PrimitiveCodable protocols.")
+    @_documentation(visibility: internal)
+    public init?(data: Data, preferredEndianness endianness: Endianness = .little) {
+        self.init(data: data, endianness: endianness)
+    }
+}
+
+
+extension ByteEncodable {
+    /// Encode to data.
+    ///
+    /// Encode the byte representation of this type.
+    ///
+    /// - Parameter endianness: The preferred endianness to use for encoding if applicable.
+    ///     This might not apply to certain data structures that operate on single byte level.
+    /// - Returns: The encoded data.
+    @available(*, deprecated, message: "Preferred Endianness was removed. Please refer to PrimitiveByteEncodable/encode(endianness:) if applicable.")
+    @_documentation(visibility: internal)
+    @_disfavoredOverload
+    public func encode(preferredEndianness endianness: Endianness = .little) -> Data {
+        var buffer = ByteBuffer()
+        encode(to: &buffer)
+        return buffer.getData(at: 0, length: buffer.readableBytes) ?? Data()
+    }
+}
+
+extension PrimitiveByteEncodable {
+    /// Encode to data.
+    ///
+    /// Encode the byte representation of this type.
+    ///
+    /// - Parameter endianness: The preferred endianness to use for encoding if applicable.
+    ///     This might not apply to certain data structures that operate on single byte level.
+    /// - Returns: The encoded data.
+    @available(*, deprecated, renamed: "encode(endianness:)", message: "Preferred Endianness was replaced by the PrimitiveCodable protocols.")
+    @_documentation(visibility: internal)
+    public func encode(preferredEndianness endianness: Endianness = .little) -> Data {
+        encode(endianness: endianness)
+    }
+}

--- a/Sources/ByteCoding/ByteCodable.swift
+++ b/Sources/ByteCoding/ByteCodable.swift
@@ -22,11 +22,8 @@ public protocol ByteDecodable {
     /// This call should move the `readerIndex` forwards.
     ///
     /// - Note: Returns nil if no valid byte representation could be found.
-    /// - Parameters:
-    ///   - byteBuffer: The ByteBuffer to read from.
-    ///   - endianness: The preferred endianness to use for decoding if applicable.
-    ///     This might not apply to certain data structures that operate on single byte level.
-    init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness)
+    /// - Parameter byteBuffer: The ByteBuffer to read from.
+    init?(from byteBuffer: inout ByteBuffer)
 }
 
 
@@ -39,51 +36,15 @@ public protocol ByteEncodable {
     /// Encode the byte representation of this type into the provided `ByteBuffer`.
     /// This call should move the `writerIndex` forwards.
     ///
-    /// - Parameters:
-    ///   - byteBuffer: The ByteBuffer to write into.
-    ///   - endianness: The preferred endianness to use for encoding if applicable.
-    ///     This might not apply to certain data structures that operate on single byte level.
-    func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness)
+    /// - Parameter byteBuffer: The ByteBuffer to write into.
+    func encode(to byteBuffer: inout ByteBuffer)
 }
 
 
-/// A type that is encodable to and decodable from and to a byte representation.
+/// A type that is encodable to and decodable from a byte representation.
 ///
 /// Conforming types can be encoded into or decodable from a `ByteBuffer`.
 public typealias ByteCodable = ByteEncodable & ByteDecodable
-
-
-extension ByteDecodable {
-    /// Decode the type from the `ByteBuffer`.
-    ///
-    /// Initialize a new instance using the byte representation provided by the `ByteBuffer`.
-    /// This call should move the `readerIndex` forwards.
-    ///
-    /// - Important: This uses `little` endianness as the default preferred endianness.
-    ///
-    /// - Note: Returns nil if no valid byte representation could be found.
-    /// - Parameter byteBuffer: The ByteBuffer to read from.
-    @_disfavoredOverload
-    public init?(from byteBuffer: inout ByteBuffer) {
-        self.init(from: &byteBuffer, preferredEndianness: .little)
-    }
-}
-
-
-extension ByteEncodable {
-    /// Encode into the `ByteBuffer`.
-    ///
-    /// Encode the byte representation of this type into the provided `ByteBuffer`.
-    /// This call should move the `writerIndex` forwards.
-    ///
-    /// - Important: This uses `little` endianness as the default preferred endianness.
-    ///
-    /// - Parameter byteBuffer: The ByteBuffer to write into.
-    @_disfavoredOverload
-    public func encode(to byteBuffer: inout ByteBuffer) {
-        self.encode(to: &byteBuffer, preferredEndianness: .little)
-    }
-}
 
 
 extension ByteDecodable {
@@ -92,13 +53,10 @@ extension ByteDecodable {
     /// Initialize a new instance using the byte representation provided.
     ///
     /// - Note: Returns nil if no valid byte representation could be found.
-    /// - Parameters:
-    ///   - data: The data to decode.
-    ///   - endianness: The preferred endianness to use for decoding if applicable.
-    ///     This might not apply to certain data structures that operate on single byte level.
-    public init?(data: Data, preferredEndianness endianness: Endianness = .little) {
+    /// - Parameter data: The data to decode.
+    public init?(data: Data) {
         var buffer = ByteBuffer(data: data)
-        self.init(from: &buffer, preferredEndianness: endianness)
+        self.init(from: &buffer)
     }
 }
 
@@ -108,12 +66,10 @@ extension ByteEncodable {
     ///
     /// Encode the byte representation of this type.
     ///
-    /// - Parameter endianness: The preferred endianness to use for encoding if applicable.
-    ///     This might not apply to certain data structures that operate on single byte level.
     /// - Returns: The encoded data.
-    public func encode(preferredEndianness endianness: Endianness = .little) -> Data {
+    public func encode() -> Data {
         var buffer = ByteBuffer()
-        encode(to: &buffer, preferredEndianness: endianness)
+        encode(to: &buffer)
         return buffer.getData(at: 0, length: buffer.readableBytes) ?? Data()
     }
 }

--- a/Sources/ByteCoding/ByteCoding.docc/ByteCoding.md
+++ b/Sources/ByteCoding/ByteCoding.docc/ByteCoding.md
@@ -18,8 +18,18 @@ This library provides a standardized approach of encoding and decoding types fro
 
 ## Topics
 
-### Coding
+### Codable Types
+
+Byte Codable types that are composed of other codable types that have a fixed byte representation.
 
 - ``ByteCodable``
 - ``ByteEncodable``
 - ``ByteDecodable``
+
+### Primitive Codable Types
+
+Byte Codable types which are not composed out of other types and which might be represented in little or big endian representation.
+
+- ``PrimitiveByteCodable``
+- ``PrimitiveByteEncodable``
+- ``PrimitiveByteDecodable``

--- a/Sources/ByteCoding/PrimitiveByteCodable.swift
+++ b/Sources/ByteCoding/PrimitiveByteCodable.swift
@@ -1,0 +1,119 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import NIOCore
+import NIOFoundationCompat
+
+
+/// A type that is decodable from a byte representation with varying endianness.
+///
+/// Conforming types can be decoded from a `ByteBuffer´ assuming it holds
+/// properly formatted binary data.
+public protocol PrimitiveByteDecodable: ByteDecodable {
+    /// Decode the type from the `ByteBuffer`.
+    ///
+    /// Initialize a new instance using the byte representation provided by the `ByteBuffer`.
+    /// The endianness specifies on which order the bytes are stored ijn the `ByteBuffer`.
+    /// This call should move the `readerIndex` forwards.
+    ///
+    /// - Note: Returns nil if no valid byte representation could be found.
+    /// - Parameters:
+    ///   - byteBuffer: The ByteBuffer to read from.
+    ///   - endianness: The order in which bytes are arranged in the ByteBuffer.
+    init?(from byteBuffer: inout ByteBuffer, endianness: Endianness)
+}
+
+
+/// A type that is decodable to a byte representation with varying endianness.
+///
+/// Conforming types can be encoded into a `ByteBuffer`.
+public protocol PrimitiveByteEncodable: ByteEncodable {
+    /// Encode into the `ByteBuffer`.
+    ///
+    /// Encode the byte representation of this type into the provided `ByteBuffer`
+    /// using the specified endianness for encoding.
+    /// This call should move the `writerIndex` forwards.
+    ///
+    /// - Parameters:
+    ///   - byteBuffer: The ByteBuffer to write into.
+    ///   - endianness: The order in which bytes are arranged in the ByteBuffer.
+    func encode(to byteBuffer: inout ByteBuffer, endianness: Endianness)
+}
+
+
+/// A type that is encodable to and decodable from a byte representation with varying endianness.
+///
+/// Conforming types can be encoded into or decodable from a `ByteBuffer` with varying endianness.
+public typealias PrimitiveByteCodable = PrimitiveByteDecodable & PrimitiveByteEncodable
+
+
+extension PrimitiveByteDecodable {
+    /// Decode the type from the `ByteBuffer`.
+    ///
+    /// Initialize a new instance using the byte representation provided by the `ByteBuffer`.
+    /// This call should move the `readerIndex` forwards.
+    ///
+    /// - Important: This uses `little` endianness as the default preferred endianness.
+    ///
+    /// - Note: Returns nil if no valid byte representation could be found.
+    /// - Parameter byteBuffer: The ByteBuffer to read from.
+    @_disfavoredOverload
+    public init?(from byteBuffer: inout ByteBuffer) {
+        self.init(from: &byteBuffer, endianness: .little)
+    }
+}
+
+
+extension PrimitiveByteEncodable {
+    /// Encode into the `ByteBuffer`.
+    ///
+    /// Encode the byte representation of this type into the provided `ByteBuffer`.
+    /// This call should move the `writerIndex` forwards.
+    ///
+    /// - Important: This uses `little` endianness as the default preferred endianness.
+    ///
+    /// - Parameter byteBuffer: The ByteBuffer to write into.
+    @_disfavoredOverload
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        self.encode(to: &byteBuffer, endianness: .little)
+    }
+}
+
+
+extension PrimitiveByteDecodable {
+    /// Decode the type from `Data`.
+    ///
+    /// Initialize a new instance using the byte representation provided.
+    ///
+    /// - Note: Returns nil if no valid byte representation could be found.
+    /// - Parameters:
+    ///   - data: The data to decode.
+    ///   - endianness: The preferred endianness to use for decoding if applicable.
+    ///     This might not apply to certain data structures that operate on single byte level.
+    public init?(data: Data, endianness: Endianness = .little) {
+        var buffer = ByteBuffer(data: data)
+        self.init(from: &buffer, endianness: endianness)
+    }
+}
+
+
+extension PrimitiveByteEncodable {
+    /// Encode to data.
+    ///
+    /// Encode the byte representation of this type.
+    ///
+    /// - Parameter endianness: The preferred endianness to use for encoding if applicable.
+    ///     This might not apply to certain data structures that operate on single byte level.
+    /// - Returns: The encoded data.
+    public func encode(endianness: Endianness = .little) -> Data {
+        var buffer = ByteBuffer()
+        encode(to: &buffer, endianness: endianness)
+        return buffer.getData(at: 0, length: buffer.readableBytes) ?? Data()
+    }
+}

--- a/Sources/ByteCoding/StandardLibrary/Bool+ByteCodable.swift
+++ b/Sources/ByteCoding/StandardLibrary/Bool+ByteCodable.swift
@@ -9,14 +9,14 @@
 import NIO
 
 
-extension Bool: ByteCodable {
+extension Bool: PrimitiveByteCodable {
     /// Decode a `Bool` from its byte representation.
     ///
     /// - Note: Note that the byte representation uses a whole byte.
     /// - Parameters:
     ///   - byteBuffer: The ByteBuffer to decode from.
     ///   - endianness: The endianness to use for decoding.
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public init?(from byteBuffer: inout ByteBuffer, endianness: Endianness) {
         guard let bytes = byteBuffer.readBytes(length: 1),
               let byte = bytes.first else {
             return nil
@@ -31,7 +31,7 @@ extension Bool: ByteCodable {
     /// - Parameters:
     ///   - byteBuffer: The ByteBuffer to write to.
     ///   - endianness: The endianness to use for encoding.
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer, endianness: Endianness) {
         byteBuffer.writeBytes([self ? 1 : 0])
     }
 }

--- a/Sources/ByteCoding/StandardLibrary/Data+ByteCodable.swift
+++ b/Sources/ByteCoding/StandardLibrary/Data+ByteCodable.swift
@@ -14,11 +14,8 @@ extension Data: ByteCodable {
     /// Decode a data blob.
     ///
     /// Copies all bytes from the ByteBuffer into a `Data` instance.
-    /// - Parameters:
-    ///   - byteBuffer: The ByteBuffer to decode from.
-    ///   - endianness: The preferred endianness to use for decoding if applicable.
-    ///     This is unused with the Data implementation.
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    /// - Parameter byteBuffer: The ByteBuffer to decode from.
+    public init?(from byteBuffer: inout ByteBuffer) {
         guard let data = byteBuffer.readData(length: byteBuffer.readableBytes) else {
             return nil
         }
@@ -28,11 +25,8 @@ extension Data: ByteCodable {
     /// Encode a data blob.
     ///
     /// Copies the data instance into the ByteBuffer.
-    /// - Parameters:
-    ///   - byteBuffer: The ByteBuffer to write to.
-    ///   - endianness: The preferred endianness to use for encoding if applicable.
-    ///     This is unused with the Data implementation.
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    /// - Parameter byteBuffer: The ByteBuffer to write to.
+    public func encode(to byteBuffer: inout ByteBuffer) {
         byteBuffer.writeData(self)
     }
 }

--- a/Sources/ByteCoding/StandardLibrary/FixedWithInteger+ByteCodable.swift
+++ b/Sources/ByteCoding/StandardLibrary/FixedWithInteger+ByteCodable.swift
@@ -10,7 +10,7 @@ import NIO
 
 
 /// `ByteCodable` types that are a `FixedWithInteger`.
-protocol FixedWidthByteCodable: FixedWidthInteger, ByteCodable {}
+protocol FixedWidthByteCodable: FixedWidthInteger, PrimitiveByteCodable {}
 
 
 extension FixedWidthByteCodable {
@@ -20,7 +20,7 @@ extension FixedWidthByteCodable {
     /// - Parameters:
     ///   - byteBuffer: The ByteBuffer to decode from.
     ///   - endianness: The endianness to use for decoding.
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public init?(from byteBuffer: inout ByteBuffer, endianness: Endianness) {
         guard let value = byteBuffer.readInteger(endianness: endianness, as: Self.self) else {
             return nil
         }
@@ -33,7 +33,7 @@ extension FixedWidthByteCodable {
     /// - Parameters:
     ///   - byteBuffer: The ByteBuffer to write to.
     ///   - endianness: The endianness to use for encoding.
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer, endianness: Endianness) {
         byteBuffer.writeInteger(self, endianness: endianness)
     }
 }

--- a/Sources/ByteCoding/StandardLibrary/Float+ByteCodable.swift
+++ b/Sources/ByteCoding/StandardLibrary/Float+ByteCodable.swift
@@ -10,15 +10,15 @@ import Foundation
 import NIO
 
 
-extension Float32: ByteCodable {
+extension Float32: PrimitiveByteCodable {
     /// Decodes a float from its byte representation.
     ///
     /// Decodes a `Float32` from a `ByteBuffer`.
     /// - Parameters:
     ///   - byteBuffer: The ByteBuffer to decode from.
     ///   - endianness: The endianness to use for decoding.
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let bitPattern = UInt32(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer, endianness: Endianness) {
+        guard let bitPattern = UInt32(from: &byteBuffer, endianness: endianness) else {
             return nil
         }
 
@@ -31,21 +31,21 @@ extension Float32: ByteCodable {
     /// - Parameters:
     ///   - byteBuffer: The ByteBuffer to write to.
     ///   - endianness: The endianness to use for encoding.
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        bitPattern.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer, endianness: Endianness) {
+        bitPattern.encode(to: &byteBuffer, endianness: endianness)
     }
 }
 
 
-extension Float64: ByteCodable {
+extension Float64: PrimitiveByteCodable {
     /// Decodes a float from its byte representation.
     ///
     /// Decodes a `Float64` from a `ByteBuffer`.
     /// - Parameters:
     ///   - byteBuffer: The ByteBuffer to decode from.
     ///   - endianness: The endianness to use for decoding.
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let bitPattern = UInt64(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer, endianness: Endianness) {
+        guard let bitPattern = UInt64(from: &byteBuffer, endianness: endianness) else {
             return nil
         }
 
@@ -58,7 +58,7 @@ extension Float64: ByteCodable {
     /// - Parameters:
     ///   - byteBuffer: The ByteBuffer to write to.
     ///   - endianness: The endianness to use for encoding.
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        bitPattern.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer, endianness: Endianness) {
+        bitPattern.encode(to: &byteBuffer, endianness: endianness)
     }
 }

--- a/Sources/ByteCoding/StandardLibrary/String+ByteCodable.swift
+++ b/Sources/ByteCoding/StandardLibrary/String+ByteCodable.swift
@@ -9,7 +9,7 @@
 import NIO
 
 
-extension String: ByteCodable {
+extension String: PrimitiveByteCodable {
     /// Decodes an utf8 string from its byte representation.
     ///
     /// Decodes an utf8 string from a `ByteBuffer`.
@@ -17,10 +17,10 @@ extension String: ByteCodable {
     /// - Note: This implementation assumes that all bytes in the ByteBuffer are representing
     ///     the string.
     /// - Parameters
-    ///   - byteBuffer: The bytebuffer to decode from.
+    ///   - byteBuffer: The ByteBuffer to decode from.
     ///   - endianness: The preferred endianness to use for decoding if applicable.
     ///     This is unused with the String implementation.
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public init?(from byteBuffer: inout ByteBuffer, endianness: Endianness) {
         guard let string = byteBuffer.readString(length: byteBuffer.readableBytes) else {
             return nil
         }
@@ -33,10 +33,10 @@ extension String: ByteCodable {
     /// Encodes an utf8 string into a `ByteBuffer`.
     ///
     /// - Parameters
-    ///   - byteBuffer: The bytebuffer to write to.
+    ///   - byteBuffer: The ByteBuffer to write to.
     ///   - endianness: The preferred endianness to use for decoding if applicable.
     ///     This is unused with the String implementation.
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer, endianness: Endianness) {
         byteBuffer.writeString(self)
     }
 }

--- a/Sources/SpeziNumerics/MedFloat16.swift
+++ b/Sources/SpeziNumerics/MedFloat16.swift
@@ -553,17 +553,17 @@ extension MedFloat16: SignedNumeric {
 }
 
 
-extension MedFloat16: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let bitPattern = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+extension MedFloat16: PrimitiveByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, endianness: Endianness) {
+        guard let bitPattern = UInt16(from: &byteBuffer, endianness: endianness) else {
             return nil
         }
 
         self.init(bitPattern: bitPattern)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        bitPattern.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer, endianness: Endianness) {
+        bitPattern.encode(to: &byteBuffer, endianness: endianness)
     }
 }
 

--- a/Tests/ByteCodingTests/ByteCodableTests.swift
+++ b/Tests/ByteCodingTests/ByteCodableTests.swift
@@ -13,6 +13,26 @@ import XCTest
 
 
 final class ByteCodableTests: XCTestCase {
+    @available(*, deprecated, message: "Forward deprecation warning.")
+    func testDeprecatedTypes() throws {
+        // ensure that preferredEndianness is still forwarded to Primitive ByteCodable protocols and isn't just ignored
+
+        let data = try XCTUnwrap(Data(hex: "0x0D05"))
+        var buffer = ByteBuffer(data: data)
+
+        let value = try XCTUnwrap(UInt16(data: data, preferredEndianness: .big))
+        let value0 = try XCTUnwrap(UInt16(from: &buffer, preferredEndianness: .big))
+        XCTAssertEqual(value, 3333)
+        XCTAssertEqual(value0, 3333)
+
+        buffer = ByteBuffer()
+
+        let data0 = value.encode(preferredEndianness: .big)
+        value0.encode(to: &buffer, preferredEndianness: .big)
+        XCTAssertEqual(data0, data)
+        XCTAssertEqual(buffer.getData(at: 0, length: buffer.readableBytes), data)
+    }
+    
     func testData() throws {
         let data = try XCTUnwrap(Data(hex: "0xAABBCCDDEE"))
 


### PR DESCRIPTION
# Introduce PrimitiveByteCodable protocols and remove preferred endianness

## :recycle: Current situation & Problem
Refer to #3 for a detailed explanation of the situation.
This PR adds new `PrimitiveByteCodable` protocols to more clearly indicate which types have a fixed byte representation and types whose endianness can be adjusted.


## :gear: Release Notes 
* Add `PrimitiveByteEncodable` and `PrimitiveByteDecodable` protocols for primitive types that support encoding and decoding with different endianness.
* Removed preferred endianness parameters for `ByteCodable` implementations

### Breaking Changes

This PR contains breaking changes and requires a major version bump.
The interface for users of ByteCodable types is kept backwards compatible (e.g., specifying preferredEndianness will be forwarded for primitive types). However, users implementing ByteCodable types will need to migrate and existing code won't compile (e.g., specifying preferredEndianness for non-primitive types will be lost). Therefore, this requires a major version bump. However, libraries updating to this version are fine with doing this as a minor version bump.

## :books: Documentation
Documentation catalog was updated.


## :white_check_mark: Testing
Additional testing was added to make sure that backwards compatibility guarantees stay valid.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
