### PR TITLE
Resolve Ambiguous overloads for Data-based encoding and decoding

### DIFF
--- a/Sources/ByteCoding/ByteCodable+Deprecated.swift
+++ b/Sources/ByteCoding/ByteCodable+Deprecated.swift
@@ -102,7 +102,7 @@ extension ByteDecodable {
     @available(*, deprecated, message: "Preferred Endianness was removed. Refer to PrimitiveByteDecodable/init(data:endianness:) if applicable.")
     @_documentation(visibility: internal)
     @_disfavoredOverload
-    public init?(data: Data, preferredEndianness endianness: Endianness = .little) {
+    public init?(data: Data, preferredEndianness endianness: Endianness) {
         var buffer = ByteBuffer(data: data)
         self.init(from: &buffer)
     }
@@ -121,7 +121,7 @@ extension PrimitiveByteDecodable {
     ///     This might not apply to certain data structures that operate on single byte level.
     @available(*, deprecated, renamed: "init(data:endianness:)", message: "Preferred Endianness was replaced by the PrimitiveCodable protocols.")
     @_documentation(visibility: internal)
-    public init?(data: Data, preferredEndianness endianness: Endianness = .little) {
+    public init?(data: Data, preferredEndianness endianness: Endianness) {
         self.init(data: data, endianness: endianness)
     }
 }
@@ -138,7 +138,7 @@ extension ByteEncodable {
     @available(*, deprecated, message: "Preferred Endianness was removed. Please refer to PrimitiveByteEncodable/encode(endianness:) if applicable.")
     @_documentation(visibility: internal)
     @_disfavoredOverload
-    public func encode(preferredEndianness endianness: Endianness = .little) -> Data {
+    public func encode(preferredEndianness endianness: Endianness) -> Data {
         var buffer = ByteBuffer()
         encode(to: &buffer)
         return buffer.getData(at: 0, length: buffer.readableBytes) ?? Data()
@@ -155,7 +155,7 @@ extension PrimitiveByteEncodable {
     /// - Returns: The encoded data.
     @available(*, deprecated, renamed: "encode(endianness:)", message: "Preferred Endianness was replaced by the PrimitiveCodable protocols.")
     @_documentation(visibility: internal)
-    public func encode(preferredEndianness endianness: Endianness = .little) -> Data {
+    public func encode(preferredEndianness endianness: Endianness) -> Data {
         encode(endianness: endianness)
     }
 }

--- a/Sources/ByteCoding/StandardLibrary/String+ByteCodable.swift
+++ b/Sources/ByteCoding/StandardLibrary/String+ByteCodable.swift
@@ -9,18 +9,15 @@
 import NIO
 
 
-extension String: PrimitiveByteCodable {
+extension String: ByteCodable {
     /// Decodes an utf8 string from its byte representation.
     ///
     /// Decodes an utf8 string from a `ByteBuffer`.
     ///
     /// - Note: This implementation assumes that all bytes in the ByteBuffer are representing
     ///     the string.
-    /// - Parameters
-    ///   - byteBuffer: The ByteBuffer to decode from.
-    ///   - endianness: The preferred endianness to use for decoding if applicable.
-    ///     This is unused with the String implementation.
-    public init?(from byteBuffer: inout ByteBuffer, endianness: Endianness) {
+    /// - Parameter byteBuffer: The ByteBuffer to decode from.
+    public init?(from byteBuffer: inout ByteBuffer) {
         guard let string = byteBuffer.readString(length: byteBuffer.readableBytes) else {
             return nil
         }
@@ -32,11 +29,8 @@ extension String: PrimitiveByteCodable {
     ///
     /// Encodes an utf8 string into a `ByteBuffer`.
     ///
-    /// - Parameters
-    ///   - byteBuffer: The ByteBuffer to write to.
-    ///   - endianness: The preferred endianness to use for decoding if applicable.
-    ///     This is unused with the String implementation.
-    public func encode(to byteBuffer: inout ByteBuffer, endianness: Endianness) {
+    /// - Parameter byteBuffer: The ByteBuffer to write to.
+    public func encode(to byteBuffer: inout ByteBuffer) {
         byteBuffer.writeString(self)
     }
 }

--- a/Tests/ByteCodingTests/ByteCodableTests.swift
+++ b/Tests/ByteCodingTests/ByteCodableTests.swift
@@ -32,7 +32,22 @@ final class ByteCodableTests: XCTestCase {
         XCTAssertEqual(data0, data)
         XCTAssertEqual(buffer.getData(at: 0, length: buffer.readableBytes), data)
     }
-    
+
+    func testAmbiguousData() throws {
+        // basically just a test if it compiles
+
+        // PRIMITIVE BYTE CODABLE
+        let data = try XCTUnwrap(Data(hex: "0x050D"))
+        let value = UInt16(data: data)
+
+        XCTAssertEqual(value, 3333)
+
+        // BYTE CODABLE
+        let stringData = try XCTUnwrap("Hello World".data(using: .utf8))
+        let stringValue = try XCTUnwrap(String(data: stringData))
+        XCTAssertEqual(stringValue, "Hello World")
+    }
+
     func testData() throws {
         let data = try XCTUnwrap(Data(hex: "0xAABBCCDDEE"))
 


### PR DESCRIPTION
# Resolve Ambiguous overloads Data-based encoding and decoding

## :recycle: Current situation & Problem
This PR fixes an issue that causes an Ambiguous overload error when trying to use Data-based encoding and decoding methods on `PrimitiveCodable` types. This was caused due to default arguments of methods that provided backwards compatibility.


## :gear: Release Notes 
* Fixed ambiguous overload error.
* Fixed String being modeled as a Primitive Byte Codable entity.


## :books: Documentation
--


## :white_check_mark: Testing
Regression tests were added.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
