### PR TITLE
Add Codable conformance for MedFloat16

### DIFF
--- a/Sources/SpeziNumerics/MedFloat16.swift
+++ b/Sources/SpeziNumerics/MedFloat16.swift
@@ -568,6 +568,19 @@ extension MedFloat16: PrimitiveByteCodable {
 }
 
 
+extension MedFloat16: Codable {
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(bitPattern: try container.decode(UInt16.self))
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(bitPattern)
+    }
+}
+
+
 extension Double {
     /// Maximum value in Double representation for a `medfloat16`.
     ///

--- a/Tests/SpeziNumericsTests/MedFloatTests.swift
+++ b/Tests/SpeziNumericsTests/MedFloatTests.swift
@@ -284,4 +284,29 @@ final class MedFloatTests: XCTestCase {
         try testIdentity(of: MedFloat16.self, from: XCTUnwrap(Data(hex: "0x0800")))
         try testIdentity(of: MedFloat16.self, from: XCTUnwrap(Data(hex: "0x0801")))
     }
+
+    func testCodable() throws {
+        func testCodableReturningResult<T: Codable & Equatable>(from value: T) throws -> T {
+            let encoder = JSONEncoder()
+            let decoder = JSONDecoder()
+
+            let data = try encoder.encode(value)
+            return try decoder.decode(T.self, from: data)
+        }
+        func testCodable<T: Codable & Equatable>(from value: T) throws {
+            let result = try testCodableReturningResult(from: value)
+            XCTAssertEqual(result, value)
+        }
+
+        try testCodable(from: MedFloat16.infinity)
+        try testCodable(from: MedFloat16.negativeInfinity)
+        try testCodable(from: MedFloat16.zero)
+        try testCodable(from: MedFloat16(12.5))
+        try testCodable(from: MedFloat16(-12.5))
+
+        // nan-like values don't compare, therefore we check for byte-wise equality
+        XCTAssertEqual(try testCodableReturningResult(from: MedFloat16.nan).bitPattern, MedFloat16.nan.bitPattern)
+        XCTAssertEqual(try testCodableReturningResult(from: MedFloat16.nres).bitPattern, MedFloat16.nres.bitPattern)
+        XCTAssertEqual(try testCodableReturningResult(from: MedFloat16.reserved0).bitPattern, MedFloat16.reserved0.bitPattern)
+    }
 }


### PR DESCRIPTION
# Add Codable conformance for MedFloat16

## :recycle: Current situation & Problem
This PR adds `Codable` conformance for the `MedFloat16` implementation encoding its bitPattern into a single value container.


## :gear: Release Notes 
* Add Codable conformance for MedFloat16


## :books: Documentation
--


## :white_check_mark: Testing
Added basic testing covering new code paths.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
