### PR TITLE
Add default implementations for RawRepresentable types with ByteCodable raw value

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 
 //
 // This source file is part of the Stanford Spezi open-source project
@@ -10,12 +10,6 @@
 
 import class Foundation.ProcessInfo
 import PackageDescription
-
-#if swift(<6)
-let swiftConcurrency: SwiftSetting = .enableExperimentalFeature("StrictConcurrency")
-#else
-let swiftConcurrency: SwiftSetting = .enableUpcomingFeature("StrictConcurrency")
-#endif
 
 
 let package = Package(
@@ -42,18 +36,12 @@ let package = Package(
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio")
             ],
-            swiftSettings: [
-                swiftConcurrency
-            ],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
             name: "XCTByteCoding",
             dependencies: [
                 .target(name: "ByteCoding")
-            ],
-            swiftSettings: [
-                swiftConcurrency
             ],
             plugins: [] + swiftLintPlugin()
         ),
@@ -63,9 +51,6 @@ let package = Package(
                 .target(name: "ByteCoding"),
                 .product(name: "NIO", package: "swift-nio")
             ],
-            swiftSettings: [
-                swiftConcurrency
-            ],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
@@ -73,9 +58,6 @@ let package = Package(
             dependencies: [
                 .target(name: "ByteCoding"),
                 .target(name: "XCTByteCoding")
-            ],
-            swiftSettings: [
-                swiftConcurrency
             ],
             plugins: [] + swiftLintPlugin()
         ),
@@ -85,9 +67,6 @@ let package = Package(
                 .target(name: "ByteCoding"),
                 .target(name: "SpeziNumerics"),
                 .target(name: "XCTByteCoding")
-            ],
-            swiftSettings: [
-                swiftConcurrency
             ],
             plugins: [] + swiftLintPlugin()
         )

--- a/Sources/ByteCoding/RawRepresentable+ByteCodable.swift
+++ b/Sources/ByteCoding/RawRepresentable+ByteCodable.swift
@@ -1,0 +1,30 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import NIOCore
+
+
+extension ByteDecodable where Self: RawRepresentable, Self.RawValue: ByteDecodable {
+    /// Decode the type from the `ByteBuffer` using the underlying `RawValue` representation.
+    /// - Parameter byteBuffer: The ByteBuffer to read from.
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = Self.RawValue(from: &byteBuffer) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+}
+
+
+extension ByteEncodable where Self: RawRepresentable, Self.RawValue: ByteEncodable {
+    /// Encode into the `ByteBuffer` using the underlying `RawValue` representation.
+    /// - Parameter byteBuffer: The ByteBuffer to write into.
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
+    }
+}

--- a/Sources/ByteCoding/RawRepresentable+PrimitiveByteCodable.swift
+++ b/Sources/ByteCoding/RawRepresentable+PrimitiveByteCodable.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import NIOCore
+
+
+extension PrimitiveByteDecodable where Self: RawRepresentable, Self.RawValue: PrimitiveByteDecodable {
+    /// Decode the type from the `ByteBuffer` using the underlying `RawValue` representation.
+    /// - Parameters:
+    ///   - byteBuffer: The ByteBuffer to read from.
+    ///   - endianness: The order in which bytes are arranged in the ByteBuffer.
+    public init?(from byteBuffer: inout ByteBuffer, endianness: Endianness) {
+        guard let rawValue = Self.RawValue(from: &byteBuffer, endianness: endianness) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+}
+
+
+extension PrimitiveByteEncodable where Self: RawRepresentable, Self.RawValue: PrimitiveByteEncodable {
+    /// Encode into the `ByteBuffer` using the underlying `RawValue` representation.
+    /// - Parameters:
+    ///   - byteBuffer: The ByteBuffer to write into.
+    ///   - endianness: The order in which bytes are arranged in the ByteBuffer.
+    public func encode(to byteBuffer: inout ByteBuffer, endianness: Endianness) {
+        rawValue.encode(to: &byteBuffer, endianness: endianness)
+    }
+}

--- a/Tests/ByteCodingTests/RawRepresentableTests.swift
+++ b/Tests/ByteCodingTests/RawRepresentableTests.swift
@@ -1,0 +1,49 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@_spi(TestingSupport) @testable import ByteCoding
+import NIO
+import XCTByteCoding
+import XCTest
+
+
+private enum SimpleEnum: UInt8, ByteCodable {
+    case hello
+    case world
+}
+
+
+private enum PrimitiveSimpleEnum: UInt16, PrimitiveByteCodable {
+    case hello
+    case world
+}
+
+
+final class RawRepresentableTests: XCTestCase {
+    func testRawRepresentableByteCodable() throws {
+        try testIdentity(from: SimpleEnum.hello)
+        try testIdentity(from: SimpleEnum.world)
+
+        // just test that overloads work and resolve
+        let data = SimpleEnum.hello.encode()
+        var buffer = ByteBuffer(data: data)
+        _ = SimpleEnum(from: &buffer)
+    }
+
+    func testRawRepresentablePrimitiveByteCodable() throws {
+        try testIdentity(from: PrimitiveSimpleEnum.hello)
+        try testIdentity(from: PrimitiveSimpleEnum.world)
+
+        // just test that overloads work and resolve
+        let data = PrimitiveSimpleEnum.hello.encode()
+        var buffer = ByteBuffer(data: data)
+        _ = PrimitiveSimpleEnum(from: &buffer, endianness: .little)
+        var buffer0 = ByteBuffer(data: data)
+        _ = PrimitiveSimpleEnum(from: &buffer0)
+    }
+}


### PR DESCRIPTION
# Add default implementations for RawRepresentable types with ByteCodable raw value

## :recycle: Current situation & Problem
This PR adds a default implementation for `ByteCodable` and `PrimitiveByteCodable` protocols for `RawRepresentable` that have a raw value type that conforms to the `ByteCodable` or `PrimitiveByteCodable` protocols.


## :gear: Release Notes 
* Make it easier to create ByteCodable RawRepresentable types.


## :books: Documentation
Added documentation for these new implementations.


## :white_check_mark: Testing
Added unit testing to verify the new overloads.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
